### PR TITLE
Fix autohook isort typo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ exclude = '''
 
 [tool.autohooks]
 mode = "poetry"
-pre-commit = ["autohooks.plugins.black",  "autohooks.plugin.isort", "autohooks.plugins.pylint"]
+pre-commit = ["autohooks.plugins.black",  "autohooks.plugins.isort", "autohooks.plugins.pylint"]
 
 [tool.pontos.version]
 version-module-file = "<FIXME>/__version__.py"


### PR DESCRIPTION
Currently the `isort` autohook plugin does not work because there is a typo in the import